### PR TITLE
[FilterJIN-7] 갤러리 이미지 로드시, 필터 item 썸네일 로드한 이미지로 초기화

### DIFF
--- a/app/src/main/java/com/example/filterjin/FilterAdapter.kt
+++ b/app/src/main/java/com/example/filterjin/FilterAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.filterjin
 
 import android.graphics.Bitmap
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -23,7 +24,7 @@ class FilterAdapter(val filterItemList: List<FilterItem>):
     override fun onBindViewHolder(holder: FilterViewHolder, position: Int) {
         holder.tv_time.text = filterItemList[position].id.toString()
         holder.tv_title.text = filterItemList[position].name
-        holder.tv_img.setImageResource(filterItemList[position].thumbnail)
+        holder.tv_img.setImageBitmap(filterItemList[position].thumbnail)
         holder.tv_name.text = filterItemList[position].imagePath
     }
 
@@ -52,6 +53,7 @@ class FilterAdapter(val filterItemList: List<FilterItem>):
         }
 
     }
+
 
 }
 

--- a/app/src/main/java/com/example/filterjin/FilterFactory.kt
+++ b/app/src/main/java/com/example/filterjin/FilterFactory.kt
@@ -1,7 +1,10 @@
 package com.example.filterjin
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.media.Image
+import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -16,6 +19,8 @@ class FilterFactory (private val context: Context) {
 
     fun getFilterItemList() : List<FilterItem>{
 
+        Log.d("FilterFactory", "getFilterItemList 시작")
+
         for (i in 0 until jsonArray.length()){
             val jsonObject = jsonArray.getJSONObject(i)
 
@@ -24,20 +29,19 @@ class FilterFactory (private val context: Context) {
             val rRatio = jsonObject.getDouble ("rRatio")
             val gRatio = jsonObject.getDouble ("gRatio")
             val bRatio = jsonObject.getDouble ("bRatio")
-
-            val thumbnail  = R.drawable.grayscale_test
+            val thumbnail  = BitmapFactory.decodeResource(context.resources, R.drawable.test)
             val imagePath = jsonObject.getString("imagePath")
 
-            val filter = FilterItem(id,name, thumbnail ,rRatio,gRatio , bRatio, imagePath)
+            try {
 
-            filterList.add(filter)
+                val filter = FilterItem(id, name, thumbnail, rRatio, gRatio, bRatio, imagePath)
+                filterList.add(filter)
+
+            }catch (e : Exception){
+                Log.e("getFilterItemList_error","${e.message}" )
+            }
         }
 
         return  filterList
     }
-
-
-
-
-
 }

--- a/app/src/main/java/com/example/filterjin/FilterItem.kt
+++ b/app/src/main/java/com/example/filterjin/FilterItem.kt
@@ -1,6 +1,11 @@
 package com.example.filterjin
 
+import android.graphics.Bitmap
 import android.media.Image
 import android.widget.ImageView
 
-data class FilterItem ( val id : Int, val name : String, val thumbnail : Int , val  rRatio : Double, val  gRatio : Double, val  bRatio : Double, val imagePath : String )
+data class FilterItem ( val id : Int, val name : String, var thumbnail : Bitmap , val  rRatio : Double, val  gRatio : Double, val  bRatio : Double, val imagePath : String){
+    fun updateThumbnail(newImage : Bitmap){
+        thumbnail = newImage
+    }
+}

--- a/app/src/main/java/com/example/filterjin/ImageViewManager.kt
+++ b/app/src/main/java/com/example/filterjin/ImageViewManager.kt
@@ -28,9 +28,6 @@ class ImageViewManager (context : Context){
     }
 
 
-    fun getCurrentImage () : Bitmap {
-        return currentImage
-    }
     fun setCurrentImage (bitmap : Bitmap) {
         currentImage = bitmap
         imageView.setImageBitmap(currentImage)

--- a/app/src/main/java/com/example/filterjin/ListViewManager.kt
+++ b/app/src/main/java/com/example/filterjin/ListViewManager.kt
@@ -12,6 +12,12 @@ import androidx.recyclerview.widget.RecyclerView
 class ListViewManager (private val context : Context,  private val mainLayout: MainLayout , private val imageViewManager : ImageViewManager) {
     private  val editBar = RecyclerView(context)
 
+    //리싸이클러뷰의 item으로 사용할 data class 데이터타입의 Filter 인스턴스 리스트 받아오기
+    private val itemList =  FilterFactory(context).getFilterItemList()
+
+    //어뎁터에 인스턴스 리스트 보내, 뷰 요소로 사용할 수 있도록 만들기
+    private val filterAdapter = FilterAdapter(itemList)
+
     fun getEditBar() : RecyclerView{
 
         editBar.apply {
@@ -21,11 +27,9 @@ class ListViewManager (private val context : Context,  private val mainLayout: M
             )
         }
 
-        //리싸이클러뷰의 item으로 사용할 data class 데이터타입의 Filter 인스턴스 리스트 받아오기
-        val itemList =  FilterFactory(context).getFilterItemList()
 
-        //어뎁터에 인스턴스 리스트 보내, 뷰 요소로 사용할 수 있도록 만들기
-        val filterAdapter = FilterAdapter(itemList)
+
+
 
         //어뎁터와 리싸이클러 뷰 갱신
         filterAdapter.notifyDataSetChanged()
@@ -46,6 +50,11 @@ class ListViewManager (private val context : Context,  private val mainLayout: M
             }
         }
         return  editBar
+    }
 
+    fun setCurrentItemImage (bitmap: Bitmap){
+        itemList.forEach { item -> item.updateThumbnail(bitmap)}
+
+        filterAdapter.notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/example/filterjin/MainLayout.kt
+++ b/app/src/main/java/com/example/filterjin/MainLayout.kt
@@ -32,8 +32,10 @@ class MainLayout(
 
     private val imageViewManager = ImageViewManager(context)
 
+    private val listViewManager = ListViewManager(context, this, imageViewManager)
+
     //ListViewManager클래스로 RecyclerView 동적구현
-    private val editBar = ListViewManager(context, this, imageViewManager).getEditBar()
+    private val editBar = listViewManager.getEditBar()
 
 
     //사용자 기기 갤러리 통해서 받아온 이미지 이미지뷰어에 띄우기
@@ -43,6 +45,7 @@ class MainLayout(
         //이미지 경로로 비트맵 이미지 객체 생성
         val bitmap = BitmapFactory.decodeStream(inputStream)
         imageViewManager.setCurrentImage(bitmap)
+        listViewManager.setCurrentItemImage(bitmap)
     }
 
     fun getMainLayout() : ConstraintLayout{


### PR DESCRIPTION
> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 갤러리로 이미지를 불러올 시, 리싸이클러뷰 안에 있는 필터 아이템들의 썸네일도 갱신됩니다.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 각 필터 아이템의 필터 기능이 적용된 이미지로 갱신해야합니다. 현재는 갤러리 원본이미지 로드

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - x
