### PR TITLE
[FilterJIN-11] 사용가 기기에 이미지 저장 기능 구현

### DIFF
--- a/app/src/main/java/com/example/filterjin/ImageProcessor.kt
+++ b/app/src/main/java/com/example/filterjin/ImageProcessor.kt
@@ -62,6 +62,11 @@ object ImageProcessor {
         lutPixels = IntArray(lutSize * lutSize)
         lutBitmap.getPixels(lutPixels, 0, lutSize, 0, 0, lutSize, lutSize)
 
+         /*
+         val startTime = System.nanoTime()
+         Log.d("startTime", "메소드 시작 시간: ${startTime/ 1_000_000_000.0} ms")
+          */
+
         // 원본 이미지의 각 픽셀에 대해 LUT를 이용하여 새 색상을 적용
         for (index in srcPixels.indices) {
             val pixel = srcPixels[index]
@@ -75,11 +80,21 @@ object ImageProcessor {
             srcPixels[index] = lutPixel
         }
 
+         /*
+         val endTime = System.nanoTime()
+         Log.d("endTime", "메소드 종료 시간: ${endTime/ 1_000_000_000.0} ms")
+
+         val duration = (endTime - startTime) / 1_000_000_000.0
+         Log.d("Performance", "메소드 실행 시간: $duration ms          사진 크기 -  w : $width   h : $height ")
+          */
+
         // 필터가 적용된 비트맵을 생성하고 반환
         val filteredBitmap = Bitmap.createBitmap(width, height, src.config)
         filteredBitmap.setPixels(srcPixels, 0, width, 0, 0, width, height)
         return filteredBitmap
     }
+
+
 
     // LUT이미지 파일을 통해 필터링한 픽셀을 반환해주는 함수
     private fun getLutPixel(red: Int, green: Int, blue: Int) : Int{

--- a/app/src/main/java/com/example/filterjin/ImageViewManager.kt
+++ b/app/src/main/java/com/example/filterjin/ImageViewManager.kt
@@ -27,6 +27,11 @@ class ImageViewManager (private val context : Context){
         return imageView
     }
 
+    fun getCurrentImage(): Bitmap {
+
+        return currentImage
+    }
+
 
     fun setCurrentImage (bitmap : Bitmap) {
         currentImage = bitmap

--- a/app/src/main/java/com/example/filterjin/MainLayout.kt
+++ b/app/src/main/java/com/example/filterjin/MainLayout.kt
@@ -1,12 +1,17 @@
 package com.example.filterjin
 
 import android.app.Activity
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import android.util.Log
 import android.view.ViewGroup
 import android.widget.Button
@@ -16,7 +21,12 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
+import androidx.core.app.ActivityCompat
 import androidx.recyclerview.widget.RecyclerView
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
 
 class MainLayout(
     private val context: Context,
@@ -170,14 +180,114 @@ class MainLayout(
 
             Toast.makeText(context, "saveBtn tapped", Toast.LENGTH_SHORT).show()
 
+            val currentImage : Bitmap = imageViewManager.getCurrentImage()
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                currentImage.let {
+                    saveImageOnAboveAndroidQ(currentImage)
+                    Toast.makeText(context, "이미지 저장이 완료되었습니다.", Toast.LENGTH_SHORT).show()
+                }
+            } else {
+                // Q 버전 이하일 경우. 저장소 권한을 얻어온다.
+                val writePermission = ActivityCompat.checkSelfPermission(context, android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+                if(writePermission == PackageManager.PERMISSION_GRANTED) {
+                    saveImageOnUnderAndroidQ(currentImage)
+                    Toast.makeText(context, "이미지 저장이 완료되었습니다.", Toast.LENGTH_SHORT).show()
+                } else {
+                    val requestExternalStorageCode = 1
+
+                    val permissionStorage = arrayOf(
+                        android.Manifest.permission.READ_EXTERNAL_STORAGE,
+                        android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+
+                    ActivityCompat.requestPermissions(context as Activity, permissionStorage, requestExternalStorageCode)
+                }
+            }
         }
-
-
-
 
 
         return  mainFrame
     }
+
+    private fun saveImageOnAboveAndroidQ(bitmap: Bitmap) {
+        val fileName = System.currentTimeMillis().toString() + ".png" // 파일이름 현재시간.png
+
+        val contentValues = ContentValues()
+        contentValues.apply {
+            put(MediaStore.Images.Media.RELATIVE_PATH, "DCIM/ImageSave")
+            put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+        Log.i("size11","w : ${bitmap.width}   h : ${bitmap.height}")
+
+
+        val uri = context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+
+        try {
+            if (uri != null) {
+                val image = context.contentResolver.openFileDescriptor(uri, "w", null)
+
+                if (image != null) {
+                    val fos = FileOutputStream(image.fileDescriptor)
+
+                    // JPEG 형식으로 압축 (압축률 조절 가능, 100은 최대 압축)
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 0, fos)
+
+                    fos.close()
+
+                    contentValues.clear()
+                    contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+                    context.contentResolver.update(uri, contentValues, null, null)
+                }
+            }
+        } catch (e: FileNotFoundException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+
+    // saveImageOnUnderAndroidQ 함수 수정
+    private fun saveImageOnUnderAndroidQ(bitmap: Bitmap) {
+        val fileName = System.currentTimeMillis().toString() + ".png"
+        val externalStorage = Environment.getExternalStorageDirectory().absolutePath
+        val path = "$externalStorage/DCIM/imageSave"
+        val dir = File(path)
+
+        Log.i("size22","w : ${bitmap.width}   h : ${bitmap.height}")
+
+        if (dir.exists().not()) {
+            dir.mkdirs()
+        }
+
+        try {
+            val fileItem = File("$dir/$fileName")
+            fileItem.createNewFile()
+
+            val fos = FileOutputStream(fileItem)
+
+            // PNG 형식으로 압축 (압축률 조절 가능, 100은 최대 압축)
+            bitmap.compress(Bitmap.CompressFormat.PNG, 0, fos)
+
+            fos.close()
+
+            // 미디어 스캔을 통해 갤러리에 반영
+            context.sendBroadcast(Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.fromFile(fileItem)))
+        } catch (e: FileNotFoundException) {
+            e.printStackTrace()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
 
 
 }


### PR DESCRIPTION
> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 사용자 기기에 현재 이미지뷰어에 띄워져있는 이미지를 저장하는 기능 구현

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 현재 LUT 필터 적용 로직 소요시간이 4000*4000 이상 크기의 이미지 기준 8초 이상 걸리는 이슈 
    사진을 저장하기 전까지는 프리뷰에 다운사이징된 이미지를 이미지 뷰어에 띄우고, 원본 이미지 크기의 아웃풋 이미지는 따로 로직을 돌며 작업되 
    도록 수정 필요. 이후 원본 이미지 크기 아웃풋 이미지는 백스레드에서 작업할지에 대해 논의 필요

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - x
